### PR TITLE
International support

### DIFF
--- a/default.py
+++ b/default.py
@@ -1,13 +1,12 @@
 ########################################################
 ## IMPORT
 ########################################################
-import re, time
+import re
 import urllib2, urllib
 import urlparse
 import json
 import xbmcgui, xbmcplugin
 from xbmcgui import ListItem
-import datetime
 
 ########################################################
 ## VARS
@@ -47,65 +46,43 @@ def add_directory(title, image_url, url):
     li = xbmcgui.ListItem(title, iconImage=image_url)
     xbmcplugin.addDirectoryItem(handle=addon_handle, url=url, listitem=li, isFolder=True)
 
-def add_video_item(title, image_url, file_url, m_index, map_typ, video_typ):
-    if map_typ != '':
-        li = xbmcgui.ListItem(title, iconImage=image_url)
-        li.setProperty('mimetype', 'video/mp4')
-        li.setProperty('IsPlayable', 'true')
-        temp_ryear = ''
-        temp_duration = ''
-        temp_title = ''
-        temp_genre = ''
-        temp_mpaa = ''
-        temp_plot = ''
-        temp_tvshowtitle = ''
-        temp_episode = ''
-        temp_season = ''
-        if video_typ == 0: #Movie
-            temp_ryear = str(map_typ['Entries'][m_index]['ReleaseYear'])
-            temp_duration = str(map_typ['Entries'][m_index]['DurationInSeconds'])
-            temp_title = map_typ['Entries'][m_index]['Title']
-            temp_genre = str(map_typ['Entries'][m_index]['Genre'])
-            temp_mpaa = str(map_typ['Entries'][m_index]['Rating'])
-            temp_plot = map_typ['Entries'][m_index]['Description']
-        elif video_typ == 1: #TV
-            temp_ryear = str(map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['ReleaseDate'])
-            temp_duration = str(map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['DurationInSeconds'])
-            temp_episode = str(map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['Episode'])
-            temp_season = str(map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['Season'])
-            if len(temp_episode) > 0 and len(temp_season) > 0:
-                temp_title = map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['Title'] + ' (S' + temp_season + 'E' + temp_episode + ')' 
-            else:
-                temp_title = map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['Title']
-            temp_genre = str(map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['Genre'])
-            temp_mpaa = str(map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['Rating'])
-            temp_plot = map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['Description']
-            temp_tvshowtitle = str(map_typ['FolderList'][0]['PlaylistList'][0]['MediaList'][m_index]['ParentChannelName'])
+def add_movie_item(info, file_url):
+    li = xbmcgui.ListItem(info['Name'].encode('utf-8'), iconImage=info['OneSheetImage_800_1200'])
+    li.setProperty('mimetype', 'video/mp4')
+    li.setProperty('IsPlayable', 'true')
+    duration = info['DurationInSeconds']
+    if duration is not None:
+        li.addStreamInfo('video', { 'duration': int(duration) })
+    d = { 'title': info['Title'], 'year': info['ReleaseYear'], 'genre': info['Genre'], 'mpaa': info['Rating'], 'plot': info['Description'] }
+    for k, v in d.items():
+        li.setInfo('video', { k: v })
+    xbmcplugin.addDirectoryItem(handle=addon_handle, url=file_url, listitem=li)
 
-        if len(temp_ryear) == 4:
-            li.setInfo('video', {'year': int(temp_ryear)})
-        elif temp_ryear.find('/') != -1:
-            li.setInfo('video', {'year': int(temp_ryear[-4:])})
-            date_spl = temp_ryear.split("/")
-            li.setInfo('video', {'aired': str(datetime.date(int(date_spl[2]), int(date_spl[0]), int(date_spl[1])).strftime('%Y-%m-%d'))})
-        if len(temp_duration) > 0 and temp_duration != "None":
-            li.addStreamInfo('video', { 'duration': int(temp_duration)})
-        if len(temp_title) > 0:
-            li.setInfo('video', {'title': temp_title})
-        if len(temp_genre) > 0:
-            li.setInfo('video', {'genre': temp_genre})
-        if len(temp_mpaa) > 0:
-            li.setInfo('video', {'mpaa': temp_mpaa})
-        if len(temp_plot) > 0:
-            li.setInfo('video', {'plot': temp_plot}) 
-        if len(temp_tvshowtitle) > 0:
-            li.setInfo('video', {'tvshowtitle': temp_tvshowtitle})
-        if len(temp_episode) > 0:
-            li.setInfo('video', {'episode': int(temp_episode)})
-        if len(temp_season) > 0:
-            li.setInfo('video', {'season': int(temp_season)})
+def add_tv_item(info, file_url):
+    li = xbmcgui.ListItem(info['Title'].encode('utf-8'), iconImage=info['OneSheetImage800x1200'])
+    li.setProperty('mimetype', 'video/mp4')
+    li.setProperty('IsPlayable', 'true')
+    li.addStreamInfo('video', { 'duration': int(info['DurationInSeconds']) })
+    d = { 'title': info['Title'], 'genre': info['Genre'], 'mpaa': info['Rating'], 'plot': info['Description'], 'tvshowtitle': info['ParentChannelName'] }
+    temp_season = info['Season']
+    temp_episode = info['Episode']
+    if len(temp_episode) > 0:
+        d['episode'] = int(temp_episode)
+    if len(temp_season) > 0:
+        d['season'] = int(temp_season)
+    if len(temp_episode) > 0 and len(temp_season) > 0:
+        d['title'] = u'%s (S%sE%s)' % (d['title'], temp_season, temp_episode) 
+    date = info['ReleaseDate'].split('/')
+    if len(date) == 3:
+        temp_rmonth = int(date[0])
+        temp_rday = int(date[1])
+        temp_ryear = int(date[2])
+        d['year'] = temp_ryear
+        d['aired'] = u'%d-%02d-%02d' % (temp_ryear, temp_rmonth, temp_rday)
 
-        xbmcplugin.addDirectoryItem(handle=addon_handle, url=file_url, listitem=li)
+    for k, v in d.items():
+        li.setInfo('video', { k: v })
+    xbmcplugin.addDirectoryItem(handle=addon_handle, url=file_url, listitem=li)
 
 def play_video():
     li = xbmcgui.ListItem(path=url)
@@ -151,10 +128,8 @@ elif mode[0] == 'movies_folder':
     jsonurl = urllib2.urlopen(movies_json_url)
     movies_map = json.loads(jsonurl.read())
     if movies_map['status']['messageCodeDescription'] == 'OK':
-        for i, info in enumerate(movies_map['Entries']):
-            if info['DurationInSeconds'] is not None and info['UserRating'] is not None:
-                add_video_item(info['Name'].encode('utf-8'), info['OneSheetImage_800_1200'], sys.argv[0]+'?mode=play_video&v_id='+str(info['ID']), i, movies_map, 0)
-
+        for info in movies_map['Entries']:
+            add_movie_item(info, sys.argv[0]+'?mode=play_video&v_id='+str(info['ID']))
     xbmcplugin.endOfDirectory(addon_handle)
 
 elif mode[0] == 'tv_folder':
@@ -177,8 +152,8 @@ elif mode[0] == 'view_episodes':
     channel_detail_map = json.loads(jsonurl.read())
 
     if channel_detail_map['status']['messageCodeDescription'] == 'OK':
-        for i, info in enumerate(channel_detail_map['FolderList'][0]['PlaylistList'][0]['MediaList']):
+        for info in channel_detail_map['FolderList'][0]['PlaylistList'][0]['MediaList']:
             pre_path = prog.findall(info['Thumbnail_Wide'])
             play_url = base_media_url % ('us', pre_path[0]) + '480p_1mbps.mp4'
-            add_video_item(info['Title'].encode('utf-8') , info['OneSheetImage800x1200'], play_url, i, channel_detail_map, 1)
+            add_tv_item(info, play_url)
     xbmcplugin.endOfDirectory(addon_handle)

--- a/default.py
+++ b/default.py
@@ -19,8 +19,6 @@ tv_json_url = 'http://api.crackle.com/Service.svc/browse/shows/full/all/alpha/us
 base_media_url = 'http://media-%s-am.crackle.com/%s'
 prog = re.compile(r''+'\/.\/.\/.{2}\/.{5}_')
 object_cnt = 0
-movies_map = ''
-tv_map = ''
 
 crackler_version = '1.0.6'
 
@@ -28,11 +26,6 @@ base_url = sys.argv[0]
 addon_handle = int(sys.argv[1])
 args = urlparse.parse_qs(sys.argv[2][1:])
 mode = args.get('mode', None)
-
-jsonurl = urllib2.urlopen(movies_json_url)
-movies_map = json.loads(jsonurl.read())
-jsonurl = urllib2.urlopen(tv_json_url)
-tv_map = json.loads(jsonurl.read())
 
 ########################################################
 ## FUNCTIONS
@@ -159,6 +152,8 @@ elif mode[0] == 'movies_folder':
     add_sort_methods(0)
     xbmcplugin.setContent(addon_handle, 'movies')
 
+    jsonurl = urllib2.urlopen(movies_json_url)
+    movies_map = json.loads(jsonurl.read())
     if movies_map['status']['messageCodeDescription'] == 'OK':
         object_cnt = int(movies_map['Count'])
         if object_cnt > 0:
@@ -171,13 +166,14 @@ elif mode[0] == 'movies_folder':
     xbmcplugin.endOfDirectory(addon_handle)
 
 elif mode[0] == 'tv_folder':
-
+    jsonurl = urllib2.urlopen(tv_json_url)
+    tv_map = json.loads(jsonurl.read())
     if tv_map['status']['messageCodeDescription'] == 'OK':
         object_cnt = int(tv_map['Count'])
         if object_cnt > 0:
             i = 0
             while i < object_cnt:
-                add_directory((tv_map['Entries'][i]['Name']).encode('utf-8') , tv_map['Entries'][i]['OneSheetImage_800_1200'], sys.argv[0]+'?mode=view_episodes&indx='+str(i)+'&v_id='+str(tv_map['Entries'][i]['ID']))
+                add_directory((tv_map['Entries'][i]['Name']).encode('utf-8') , tv_map['Entries'][i]['OneSheetImage_800_1200'], sys.argv[0]+'?mode=view_episodes&v_id='+str(tv_map['Entries'][i]['ID']))
                 i += 1
     xbmcplugin.endOfDirectory(addon_handle)
 
@@ -187,8 +183,6 @@ elif mode[0] == 'play_video':
 elif mode[0] == 'view_episodes':
     add_sort_methods(1)
     xbmcplugin.setContent(addon_handle, 'episodes')
-    jsonurl = urllib2.urlopen(tv_json_url)
-    tv_map = json.loads(jsonurl.read())
 
     args_ar = dict(urlparse.parse_qsl(sys.argv[2].replace('?','')))
     jsonurl = urllib2.urlopen(channel_detail_url % (args_ar['v_id']))
@@ -201,6 +195,6 @@ elif mode[0] == 'view_episodes':
             while j < object_cnt:
                 pre_path = prog.findall(channel_detail_map['FolderList'][0]['PlaylistList'][0]['MediaList'][j]['Thumbnail_Wide'])
                 play_url = base_media_url % ('us', pre_path[0]) + '480p_1mbps.mp4'
-                add_video_item((channel_detail_map['FolderList'][0]['PlaylistList'][0]['MediaList'][j]['Title']).encode('utf-8') , tv_map['Entries'][int(args_ar['indx'])]['OneSheetImage_800_1200'], play_url, j, channel_detail_map, 1)
+                add_video_item((channel_detail_map['FolderList'][0]['PlaylistList'][0]['MediaList'][j]['Title']).encode('utf-8') , channel_detail_map['FolderList'][0]['PlaylistList'][0]['MediaList'][j]['OneSheetImage800x1200'], play_url, j, channel_detail_map, 1)
                 j += 1
     xbmcplugin.endOfDirectory(addon_handle)


### PR DESCRIPTION
These commits add support for other countries.  Crackler now determines the user's country and retrieves appropriate movie and TV listings for that country.  The code has been updated to eliminate unnecessary network traffic, handle non-ASCII characters, and be more robust against incomplete fields and channel organisation.
